### PR TITLE
19 feat chapter 10 linked list

### DIFF
--- a/collections/list/Cargo.toml
+++ b/collections/list/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "utlist"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+[dev-dependencies]
+rand = "0.9"

--- a/collections/list/Cargo.toml
+++ b/collections/list/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "utlist"
+name = "list"
 version = "0.1.0"
 edition = "2024"
 

--- a/collections/list/src/into_iter.rs
+++ b/collections/list/src/into_iter.rs
@@ -1,0 +1,40 @@
+use super::List;
+use crate::node::*;
+use std::boxed::Box;
+use std::iter::Iterator;
+use std::ptr::NonNull;
+
+#[derive(Debug)]
+pub struct IntoIter<T> {
+    source: Option<NonNull<Node<T>>>,
+    len: usize,
+}
+
+impl<T> IntoIter<T> {
+    pub(super) fn new(list: List<T>) -> Self {
+        // move ownership of nodes to the iterator
+        let result = IntoIter {
+            source: list.head,
+            len: list.len,
+        };
+        // to prevent double free, make list empty
+        let mut list = list;
+        list.head = None;
+        list.tail = None;
+        list.len = 0;
+        result
+    }
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(cur_node) = self.source {
+            self.source = Node::get_next_node(cur_node);
+            self.len -= 1;
+            unsafe { Some(Box::from_raw(cur_node.as_ptr()).get_data()) } // consume node here
+        } else {
+            None
+        }
+    }
+}

--- a/collections/list/src/into_iter.rs
+++ b/collections/list/src/into_iter.rs
@@ -1,9 +1,26 @@
+//! # `List`를 위한 소유 반복자
+//!
+//! 이 반복자는 `List`의 `into_iter` 메소드에 의해 생성됩니다.
+
 use super::List;
 use crate::node::*;
 use std::boxed::Box;
 use std::iter::{ExactSizeIterator, FusedIterator, Iterator};
 use std::ptr::NonNull;
 
+/// # `List`를 위한 소유 반복자
+///
+/// 이 구조체는 `List`의 `into_iter` 메소드에 의해 생성됩니다.
+/// 자세한 내용은 해당 문서를 참조하세요.
+///
+/// # 제네릭
+///
+/// * `T`: 반복자가 반환할 요소의 타입입니다.
+///
+/// # 필드
+///
+/// * `source`: 현재 노드를 가리키는 포인터입니다.
+/// * `len`: 반복자에 남아있는 요소의 수입니다.
 #[derive(Debug)]
 pub struct IntoIter<T> {
     source: Option<NonNull<Node<T>>>,
@@ -11,6 +28,14 @@ pub struct IntoIter<T> {
 }
 
 impl<T> IntoIter<T> {
+    /// # `List`로부터 새로운 `IntoIter`를 생성합니다.
+    ///
+    /// 이 함수는 `List`와 그 노드들의 소유권을 가져옵니다.
+    /// 이중 해제를 방지하기 위해, 원래의 `List`는 비워집니다.
+    ///
+    /// # 인수
+    ///
+    /// * `list`: 소유권을 가져올 `List`입니다.
     pub(super) fn new(list: List<T>) -> Self {
         // move ownership of nodes to the iterator
         let result = IntoIter {
@@ -28,15 +53,26 @@ impl<T> IntoIter<T> {
 
 impl<T> Iterator for IntoIter<T> {
     type Item = T;
+
+    /// # 반복자를 진행시키고 다음 값을 반환합니다.
+    ///
+    /// 노드를 소비하고 데이터를 반환합니다.
+    ///
+    /// # 반환값
+    ///
+    /// 다음 요소를 담은 `Option<T>`입니다.
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(cur_node) = self.source {
             self.source = Node::get_next_node(cur_node);
             self.len -= 1;
-            unsafe { Some(Box::from_raw(cur_node.as_ptr()).get_data()) } // consume node here
+            // consume node here
+            unsafe { Some(Box::from_raw(cur_node.as_ptr()).get_data()) }
         } else {
             None
         }
     }
+
+    /// # 반복자의 정확한 크기를 반환합니다.
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len, Some(self.len)) // exact size
     }

--- a/collections/list/src/into_iter.rs
+++ b/collections/list/src/into_iter.rs
@@ -1,7 +1,7 @@
 use super::List;
 use crate::node::*;
 use std::boxed::Box;
-use std::iter::Iterator;
+use std::iter::{ExactSizeIterator, FusedIterator, Iterator};
 use std::ptr::NonNull;
 
 #[derive(Debug)]
@@ -37,4 +37,11 @@ impl<T> Iterator for IntoIter<T> {
             None
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len)) // exact size
+    }
 }
+
+impl<T> ExactSizeIterator for IntoIter<T> {}
+
+impl<T> FusedIterator for IntoIter<T> {}

--- a/collections/list/src/iter.rs
+++ b/collections/list/src/iter.rs
@@ -1,0 +1,36 @@
+use super::List;
+use crate::node::*;
+use std::iter::Iterator;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+#[derive(Debug)]
+pub struct Iter<'a, T> {
+    source: Option<NonNull<Node<T>>>,
+    len: usize,
+    phantom: PhantomData<&'a Node<T>>,
+}
+
+impl<'a, T> Iter<'a, T> {
+    pub(super) fn new(list: &'a List<T>) -> Self {
+        Iter {
+            source: list.head,
+            len: list.len,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(cur_node) = self.source {
+            let result = unsafe { Some(cur_node.as_ref().get_data_ref()) };
+            self.source = Node::get_next_node(cur_node);
+            self.len -= 1;
+            result
+        } else {
+            None
+        }
+    }
+}

--- a/collections/list/src/iter.rs
+++ b/collections/list/src/iter.rs
@@ -25,10 +25,9 @@ impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(cur_node) = self.source {
-            let result = unsafe { Some(cur_node.as_ref().get_data_ref()) };
             self.source = Node::get_next_node(cur_node);
             self.len -= 1;
-            result
+            unsafe { Some(cur_node.as_ref().get_data_ref()) }
         } else {
             None
         }

--- a/collections/list/src/iter.rs
+++ b/collections/list/src/iter.rs
@@ -1,9 +1,28 @@
+//! # `List`의 항목에 대한 반복자
+//!
+//! 이 반복자는 `List`의 `iter` 메소드에 의해 생성됩니다.
+
 use super::List;
 use crate::node::*;
 use std::iter::{FusedIterator, Iterator};
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
+/// # `List`의 항목에 대한 반복자
+///
+/// 이 구조체는 `List`의 `iter` 메소드에 의해 생성됩니다.
+/// 자세한 내용은 해당 문서를 참조하세요.
+///
+/// # 제네릭
+///
+/// * `'a`: 반복자의 라이프타임입니다.
+/// * `T`: 반복자가 반환할 요소의 타입입니다.
+///
+/// # 필드
+///
+/// * `source`: 현재 노드를 가리키는 포인터입니다.
+/// * `len`: 반복자에 남아있는 요소의 수입니다.
+/// * `phantom`: 라이프타임 `'a`를 사용하기 위한 팬텀 데이터입니다.
 #[derive(Debug)]
 pub struct Iter<'a, T> {
     source: Option<NonNull<Node<T>>>,
@@ -12,6 +31,7 @@ pub struct Iter<'a, T> {
 }
 
 impl<'a, T> Iter<'a, T> {
+    /// # `List`로부터 새로운 `Iter`를 생성합니다.
     pub(super) fn new(list: &'a List<T>) -> Self {
         Iter {
             source: list.head,
@@ -23,6 +43,8 @@ impl<'a, T> Iter<'a, T> {
 
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
+
+    /// # 반복자를 진행시키고 다음 값을 반환합니다.
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(cur_node) = self.source {
             self.source = Node::get_next_node(cur_node);
@@ -32,12 +54,15 @@ impl<'a, T> Iterator for Iter<'a, T> {
             None
         }
     }
+
+    /// # 반복자의 정확한 크기를 반환합니다.
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len, Some(self.len)) // exact size
     }
 }
 
 impl<T> DoubleEndedIterator for Iter<'_, T> {
+    /// # 반복자를 뒤에서부터 진행시키고 다음 값을 반환합니다.
     fn next_back(&mut self) -> Option<Self::Item> {
         if let Some(cur_node) = self.source {
             self.source = Node::get_prev_node(cur_node);

--- a/collections/list/src/iter.rs
+++ b/collections/list/src/iter.rs
@@ -1,6 +1,6 @@
 use super::List;
 use crate::node::*;
-use std::iter::Iterator;
+use std::iter::{FusedIterator, Iterator};
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
@@ -32,4 +32,23 @@ impl<'a, T> Iterator for Iter<'a, T> {
             None
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len)) // exact size
+    }
 }
+
+impl<T> DoubleEndedIterator for Iter<'_, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if let Some(cur_node) = self.source {
+            self.source = Node::get_prev_node(cur_node);
+            self.len += 1;
+            unsafe { Some(cur_node.as_ref().get_data_ref()) }
+        } else {
+            None
+        }
+    }
+}
+
+impl<T> ExactSizeIterator for Iter<'_, T> {}
+
+impl<T> FusedIterator for Iter<'_, T> {}

--- a/collections/list/src/iter_mut.rs
+++ b/collections/list/src/iter_mut.rs
@@ -25,10 +25,9 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(mut cur_node) = self.source {
-            let result = unsafe { Some(cur_node.as_mut().get_data_mut_ref()) };
             self.source = Node::get_next_node(cur_node);
             self.len -= 1;
-            result
+            unsafe { Some(cur_node.as_mut().get_data_mut_ref()) }
         } else {
             None
         }

--- a/collections/list/src/iter_mut.rs
+++ b/collections/list/src/iter_mut.rs
@@ -1,0 +1,36 @@
+use super::List;
+use crate::node::*;
+use std::iter::Iterator;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+#[derive(Debug)]
+pub struct IterMut<'a, T> {
+    source: Option<NonNull<Node<T>>>,
+    len: usize,
+    phantom: PhantomData<&'a mut Node<T>>,
+}
+
+impl<'a, T> IterMut<'a, T> {
+    pub(super) fn new(list: &'a mut List<T>) -> Self {
+        IterMut {
+            source: list.head,
+            len: list.len,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> Iterator for IterMut<'a, T> {
+    type Item = &'a mut T;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(mut cur_node) = self.source {
+            let result = unsafe { Some(cur_node.as_mut().get_data_mut_ref()) };
+            self.source = Node::get_next_node(cur_node);
+            self.len -= 1;
+            result
+        } else {
+            None
+        }
+    }
+}

--- a/collections/list/src/iter_mut.rs
+++ b/collections/list/src/iter_mut.rs
@@ -1,6 +1,6 @@
 use super::List;
 use crate::node::*;
-use std::iter::Iterator;
+use std::iter::{ExactSizeIterator, FusedIterator, Iterator};
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
@@ -32,4 +32,23 @@ impl<'a, T> Iterator for IterMut<'a, T> {
             None
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len)) // exact size
+    }
 }
+
+impl<T> DoubleEndedIterator for IterMut<'_, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if let Some(mut cur_node) = self.source {
+            self.source = Node::get_prev_node(cur_node);
+            self.len += 1;
+            unsafe { Some(cur_node.as_mut().get_data_mut_ref()) }
+        } else {
+            None
+        }
+    }
+}
+
+impl<T> ExactSizeIterator for IterMut<'_, T> {}
+
+impl<T> FusedIterator for IterMut<'_, T> {}

--- a/collections/list/src/iter_mut.rs
+++ b/collections/list/src/iter_mut.rs
@@ -1,9 +1,28 @@
+//! # `List`의 항목에 대한 가변 반복자
+//!
+//! 이 반복자는 `List`의 `iter_mut` 메소드에 의해 생성됩니다.
+
 use super::List;
 use crate::node::*;
 use std::iter::{ExactSizeIterator, FusedIterator, Iterator};
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
+/// # `List`의 항목에 대한 가변 반복자
+///
+/// 이 구조체는 `List`의 `iter_mut` 메소드에 의해 생성됩니다.
+/// 자세한 내용은 해당 문서를 참조하세요.
+///
+/// # 제네릭
+///
+/// * `'a`: 반복자의 라이프타임입니다.
+/// * `T`: 반복자가 반환할 요소의 타입입니다.
+///
+/// # 필드
+///
+/// * `source`: 현재 노드를 가리키는 포인터입니다.
+/// * `len`: 반복자에 남아있는 요소의 수입니다.
+/// * `phantom`: 라이프타임 `'a`를 사용하기 위한 팬텀 데이터입니다.
 #[derive(Debug)]
 pub struct IterMut<'a, T> {
     source: Option<NonNull<Node<T>>>,
@@ -12,6 +31,7 @@ pub struct IterMut<'a, T> {
 }
 
 impl<'a, T> IterMut<'a, T> {
+    /// # `List`로부터 새로운 `IterMut`를 생성합니다.
     pub(super) fn new(list: &'a mut List<T>) -> Self {
         IterMut {
             source: list.head,
@@ -23,6 +43,8 @@ impl<'a, T> IterMut<'a, T> {
 
 impl<'a, T> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
+
+    /// # 반복자를 진행시키고 다음 값을 반환합니다.
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(mut cur_node) = self.source {
             self.source = Node::get_next_node(cur_node);
@@ -32,12 +54,15 @@ impl<'a, T> Iterator for IterMut<'a, T> {
             None
         }
     }
+
+    /// # 반복자의 정확한 크기를 반환합니다.
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len, Some(self.len)) // exact size
     }
 }
 
 impl<T> DoubleEndedIterator for IterMut<'_, T> {
+    /// # 반복자를 뒤에서부터 진행시키고 다음 값을 반환합니다.
     fn next_back(&mut self) -> Option<Self::Item> {
         if let Some(mut cur_node) = self.source {
             self.source = Node::get_prev_node(cur_node);

--- a/collections/list/src/lib.rs
+++ b/collections/list/src/lib.rs
@@ -1,0 +1,369 @@
+mod node;
+
+use crate::node::*;
+use std::default::Default;
+use std::iter;
+use std::ptr::NonNull;
+use std::result::Result;
+
+// data types
+#[derive(Debug)]
+pub struct List<T> {
+    len: usize,
+    head: Option<NonNull<Node<T>>>,
+    tail: Option<NonNull<Node<T>>>,
+}
+
+// private methods
+impl<T> List<T> {
+    fn alloc_node(data: T) -> NonNull<Node<T>> {
+        let boxed_new_node = Box::new(Node::<T>::new(data));
+        NonNull::new(Box::into_raw(boxed_new_node)).unwrap() // fuck
+    }
+    // fn free_node(node: NonNull<Node<T>>) {
+    //     unsafe { drop(Box::from_raw(node.as_ptr())) }
+    // }
+    fn at(&self, pos: usize) -> Option<NonNull<Node<T>>> {
+        if pos >= self.len() {
+            return None;
+        }
+        let mut target_node = self.head.unwrap();
+        for _ in 0..pos {
+            // O(N)
+            target_node = Node::get_next_node(target_node).unwrap();
+        }
+        Some(target_node)
+    }
+    fn insert_when_empty(&mut self, node: NonNull<Node<T>>) {
+        self.head = Some(node);
+        self.tail = Some(node);
+        self.len += 1;
+    }
+    fn pop_last(&mut self) -> Result<T, &str> {
+        let result = if let Some(node) = self.head {
+            unsafe { Ok((*Box::from_raw(node.as_ptr())).get_data()) }
+        } else {
+            Err("Error : pos out of range.")
+        };
+        self.head = None;
+        self.tail = None;
+        self.len = 0;
+        result
+    }
+}
+
+// public methods
+impl<T> List<T> {
+    pub fn new() -> Self {
+        Self {
+            len: 0usize,
+            head: None,
+            tail: None,
+        }
+    }
+    pub fn from_slice(slice: &[T]) -> Self
+    where
+        T: Clone,
+    {
+        let mut list = List::<T>::new();
+        for data in slice {
+            list.push_back(data.clone());
+        }
+        list
+    }
+    pub fn len(&self) -> usize {
+        self.len
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len == 0usize
+    }
+
+    // 삽입
+    pub fn push_front(&mut self, data: T) {
+        let new_node = List::alloc_node(data);
+        if self.is_empty() {
+            List::insert_when_empty(self, new_node);
+        } else {
+            Node::link_nodes(new_node, self.head.unwrap());
+            self.head = Some(new_node);
+            self.len += 1;
+        }
+    }
+    pub fn push_back(&mut self, data: T) {
+        let new_node = List::alloc_node(data);
+        if self.is_empty() {
+            List::insert_when_empty(self, new_node);
+        } else {
+            Node::link_nodes(self.tail.unwrap(), new_node);
+            self.tail = Some(new_node);
+            self.len += 1;
+        }
+    }
+    pub fn insert_at(&mut self, data: T, pos: usize) -> Result<(), &str> {
+        // push back
+        match pos {
+            0 => {
+                self.push_front(data);
+                Ok(())
+            }
+            other => {
+                if other == self.len {
+                    self.push_back(data);
+                    return Ok(());
+                }
+                if let Some(target_node) = self.at(pos) {
+                    let new_node = List::alloc_node(data);
+                    Node::insert_before(new_node, target_node);
+                    self.len += 1;
+                    Ok(())
+                } else {
+                    Err("Error : out of range.")
+                }
+            }
+        }
+    }
+
+    pub fn pop_front(&mut self) -> Result<T, &str> {
+        if self.len == 0 {
+            Err("Error : out of range.")
+        } else if self.len == 1 {
+            self.pop_last()
+        } else {
+            let new_head = Node::get_next_node(self.head.unwrap());
+            let result = unsafe { Ok((*Box::from_raw(self.head.unwrap().as_ptr())).get_data()) };
+            self.head = new_head;
+            self.len -= 1;
+            result
+        }
+    }
+    pub fn pop_back(&mut self) -> Result<T, &str> {
+        if self.len == 0 {
+            Err("Error : out of range.")
+        } else if self.len == 1 {
+            self.pop_last()
+        } else {
+            let new_tail = Node::get_prev_node(self.tail.unwrap());
+            let result = unsafe { Ok((*Box::from_raw(self.tail.unwrap().as_ptr())).get_data()) };
+            self.tail = new_tail;
+            self.len -= 1;
+            result
+        }
+    }
+
+    pub fn get(&mut self, pos: usize) -> Result<T, &str> {
+        if pos == 0 {
+            return self.pop_front();
+        } else if pos == self.len - 1 {
+            return self.pop_back();
+        }
+        // normal get
+        self.len -= 1;
+        if let Some(node) = self.at(pos) {
+            unsafe { Ok((*Box::from_raw(node.as_ptr())).get_data()) }
+        } else {
+            Err("Error : pos out of range.")
+        }
+    }
+    pub fn get_ref(&self, pos: usize) -> Result<&T, &str> {
+        if let Some(node) = self.at(pos) {
+            unsafe { Ok(node.as_ref().get_data_ref()) }
+        } else {
+            Err("Error : pos out of range.")
+        }
+    }
+    pub fn get_mut_ref(&mut self, pos: usize) -> Result<&mut T, &str> {
+        if let Some(mut node) = self.at(pos) {
+            unsafe { Ok(node.as_mut().get_data_mut_ref()) }
+        } else {
+            Err("Error : pos out of range.")
+        }
+    }
+    pub fn erase_at(&mut self, pos: usize) -> Result<(), &str> {
+        let result = self.get(pos);
+        if result.is_ok() {
+            Ok(())
+        } else {
+            Err(result.err().unwrap())
+        }
+    }
+    pub fn clear(&mut self) {
+        // consume all node
+        while self.pop_back().is_ok() {
+            // do nothing
+        }
+    }
+
+    // iter()
+    // iterMut()
+    // into_iter()
+    // from_iter()
+}
+
+// trait implementations
+impl<T> Default for List<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Drop for List<T> {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
+impl<T> PartialEq for List<T>
+where
+    Node<T>: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+        let mut cur_my = self.head;
+        let mut cur_other = other.head;
+        while cur_my.is_some() {
+            // synthetic sugar?
+            unsafe {
+                if cur_my.unwrap().as_ref() != cur_other.unwrap().as_ref() {
+                    return false;
+                }
+                cur_my = Node::get_next_node(cur_my.unwrap());
+                cur_other = Node::get_next_node(cur_other.unwrap());
+            }
+        }
+        true
+    }
+}
+
+impl<T> Eq for List<T>
+where
+    Node<T>: Eq,
+    List<T>: PartialEq,
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::*;
+
+    #[test]
+    fn test_single_node() {
+        let mut l = List::<i32>::new();
+        l.push_back(33);
+        assert_eq!(l, List::<i32>::from_slice(&[33]));
+    }
+
+    #[test]
+    fn test_multi_node() {
+        let mut l = List::<i32>::new();
+
+        l.push_back(42);
+        l.push_back(33);
+        l.push_back(21);
+        assert_eq!(l.len(), 3);
+        assert_eq!(l, List::<i32>::from_slice(&[42, 33, 21]));
+    }
+    #[test]
+    fn test_size() {
+        let mut l = List::<i32>::new();
+
+        l.push_back(42);
+        l.push_back(42);
+        assert_eq!(l.len(), 2);
+        assert_eq!(l.erase_at(0), Ok(()));
+        assert_eq!(l.len(), 1);
+        assert_eq!(l.erase_at(0), Ok(()));
+        assert_eq!(l.len(), 0);
+        assert!(l.is_empty());
+    }
+    #[test]
+    fn test_get() {
+        let mut l = List::<i32>::new();
+
+        l.push_back(42);
+        assert_eq!(l.get(0), Ok(42i32));
+    }
+
+    #[test]
+    fn test_ref() {
+        let l = List::<i32>::from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+
+        assert_eq!(*(l.get_ref(0).unwrap()), 1);
+        assert_eq!(*(l.get_ref(1).unwrap()), 2);
+        assert_eq!(*(l.get_ref(2).unwrap()), 3);
+        assert_eq!(*(l.get_ref(3).unwrap()), 4);
+        assert_eq!(*(l.get_ref(4).unwrap()), 5);
+        assert_eq!(*(l.get_ref(5).unwrap()), 6);
+        assert_eq!(*(l.get_ref(6).unwrap()), 7);
+        assert!((l.get_ref(7)).is_err());
+    }
+    #[test]
+    fn test_mut_ref() {
+        let mut l = List::<i32>::from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+
+        assert_eq!(*(l.get_mut_ref(0).unwrap()), 1);
+        assert_eq!(*(l.get_mut_ref(1).unwrap()), 2);
+        assert_eq!(*(l.get_mut_ref(2).unwrap()), 3);
+        assert_eq!(*(l.get_mut_ref(3).unwrap()), 4);
+        assert_eq!(*(l.get_mut_ref(4).unwrap()), 5);
+        assert_eq!(*(l.get_mut_ref(5).unwrap()), 6);
+        assert_eq!(*(l.get_mut_ref(6).unwrap()), 7);
+        assert!((l.get_mut_ref(7)).is_err());
+
+        let mut_ref = l.get_mut_ref(0).unwrap();
+        *mut_ref = 42;
+        assert_eq!(*(l.get_ref(0).unwrap()), 42);
+        let mut_ref2 = l.get_mut_ref(3).unwrap();
+        *mut_ref2 = 44;
+        assert_eq!(*(l.get_ref(3).unwrap()), 44);
+    }
+    #[test]
+    fn test_insert() {
+        let mut l = List::<i32>::from_slice(&[1, 2, 3, 4, 5, 6]);
+
+        l.insert_at(0, 0).expect("FIRST INSERTION FAILED");
+        assert_eq!(l, List::<i32>::from_slice(&[0, 1, 2, 3, 4, 5, 6]));
+
+        l.insert_at(7, 7).expect("LAST INSERTION FAILED");
+        assert_eq!(l, List::<i32>::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7]));
+
+        for n in 0..=7 {
+            l.insert_at(n, n as usize).expect("INSERTION FAILED");
+        }
+        assert_eq!(
+            l,
+            List::<i32>::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7])
+        );
+    }
+    #[test]
+    fn test_erase() {
+        let mut l = List::<i32>::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7]);
+
+        // erase head
+        l.erase_at(0).expect("HEAD ERASE FAILED");
+        assert_eq!(l, List::<i32>::from_slice(&[1, 2, 3, 4, 5, 6, 7]));
+
+        // erase tail
+        let last = l.len() - 1;
+        l.erase_at(last).expect("TAIL ERASE FAILED");
+        assert_eq!(l, List::<i32>::from_slice(&[1, 2, 3, 4, 5, 6]));
+
+        // erase mid
+        l.erase_at(3).expect("MID ERASE FAILED");
+        assert_eq!(l, List::<i32>::from_slice(&[1, 2, 3, 5, 6]));
+        l.erase_at(2).expect("MID ERASE FAILED");
+        assert_eq!(l, List::<i32>::from_slice(&[1, 2, 5, 6]));
+
+        // erase all
+        l.clear();
+        assert_eq!(l, List::<i32>::new());
+
+        // push after erase all
+        l.push_front(3);
+        l.push_front(2);
+        l.push_front(1);
+        assert_eq!(l, List::<i32>::from_slice(&[1, 2, 3]));
+    }
+}

--- a/collections/list/src/lib.rs
+++ b/collections/list/src/lib.rs
@@ -1,8 +1,13 @@
+mod into_iter;
+mod iter;
+mod iter_mut;
 mod node;
 
+use crate::into_iter::*;
+use crate::iter::*;
+use crate::iter_mut::*;
 use crate::node::*;
 use std::default::Default;
-use std::iter;
 use std::ptr::NonNull;
 use std::result::Result;
 
@@ -37,7 +42,7 @@ impl<T> List<T> {
     fn insert_when_empty(&mut self, node: NonNull<Node<T>>) {
         self.head = Some(node);
         self.tail = Some(node);
-        self.len += 1;
+        self.len = 1;
     }
     fn pop_last(&mut self) -> Result<T, &str> {
         let result = if let Some(node) = self.head {
@@ -193,10 +198,18 @@ impl<T> List<T> {
         }
     }
 
-    // iter()
-    // iterMut()
     // into_iter()
     // from_iter()
+}
+
+impl<'a, T> List<T> {
+    pub fn iter(&'a self) -> Iter<'a, T> {
+        Iter::new(self)
+    }
+
+    pub fn iter_mut(&'a mut self) -> IterMut<'a, T> {
+        IterMut::new(self)
+    }
 }
 
 // trait implementations
@@ -243,10 +256,33 @@ where
 {
 }
 
+impl<'a, T> std::iter::IntoIterator for &'a List<T> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        Iter::new(self)
+    }
+}
+
+impl<'a, T> std::iter::IntoIterator for &'a mut List<T> {
+    type Item = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        IterMut::new(self)
+    }
+}
+
+impl<T> std::iter::IntoIterator for List<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter::new(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::*;
 
     #[test]
     fn test_single_node() {
@@ -365,5 +401,79 @@ mod tests {
         l.push_front(2);
         l.push_front(1);
         assert_eq!(l, List::<i32>::from_slice(&[1, 2, 3]));
+    }
+
+    #[test]
+    fn test_iter() {
+        let l = List::<i32>::from_slice(&[1, 2, 3, 4, 5]);
+        let mut itr = l.iter();
+        assert_eq!(*itr.next().unwrap(), 1);
+        assert_eq!(*itr.next().unwrap(), 2);
+        assert_eq!(*itr.next().unwrap(), 3);
+        // let data = l.get(2); // with this line, must not compile. borrow check.
+        assert_eq!(*itr.next().unwrap(), 4);
+        assert_eq!(*itr.next().unwrap(), 5);
+        assert_eq!(itr.next(), None);
+
+        let mut cnt = 1;
+        for i in l.iter() {
+            assert_eq!(*i, cnt);
+            cnt += 1;
+        }
+
+        let mut cnt = 3;
+        for i in l.iter().map(|x| x * 3) {
+            assert_eq!(i, cnt);
+            cnt += 3;
+        }
+    }
+    #[test]
+    fn test_iter_mut() {
+        let mut l = List::<i32>::from_slice(&[1, 2, 3, 4, 5]);
+        let mut itr = l.iter_mut();
+        assert_eq!(*itr.next().unwrap(), 1);
+        assert_eq!(*itr.next().unwrap(), 2);
+        assert_eq!(*itr.next().unwrap(), 3);
+        // let data = l.get(2); // with this line, must not compile. borrow check.
+        assert_eq!(*itr.next().unwrap(), 4);
+        assert_eq!(*itr.next().unwrap(), 5);
+        assert_eq!(itr.next(), None);
+
+        let mut cnt = 1;
+        for i in l.iter_mut() {
+            assert_eq!(*i, cnt);
+            cnt += 1;
+        }
+
+        let mut cnt = 3;
+        l.iter_mut().for_each(|x| *x *= 3); // change content through IterMut
+        for i in l.iter() {
+            assert_eq!(*i, cnt);
+            cnt += 3;
+        }
+    }
+    #[test]
+    fn test_into_iter_trait() {
+        let mut l = List::<i32>::from_slice(&[1, 2, 3, 4, 5]);
+
+        // test for &List
+        let mut val = 1;
+        for i in &l {
+            assert_eq!(val, *i);
+            val += 1;
+        }
+        // test for &mut List
+        let mut val = 2;
+        for i in &mut l {
+            *i *= 2;
+            assert_eq!(val, *i);
+            val += 2;
+        }
+        // test for List
+        let mut val = 2;
+        for i in l {
+            assert_eq!(val, i);
+            val += 2;
+        }
     }
 }

--- a/collections/list/src/lib.rs
+++ b/collections/list/src/lib.rs
@@ -1,3 +1,5 @@
+//! A doubly-linked list implementation.
+
 mod into_iter;
 mod iter;
 mod iter_mut;
@@ -11,7 +13,19 @@ use std::default::Default;
 use std::ptr::NonNull;
 use std::result::Result;
 
-// data types
+/// # 이중 연결 리스트
+///
+/// `List`는 이중 연결 리스트를 나타냅니다.
+///
+/// # 제네릭
+///
+/// * `T`: 리스트에 저장될 요소의 타입입니다.
+///
+/// # 필드
+///
+/// * `len`: 리스트의 길이입니다.
+/// * `head`: 리스트의 첫 번째 노드를 가리키는 포인터입니다.
+/// * `tail`: 리스트의 마지막 노드를 가리키는 포인터입니다.
 #[derive(Debug)]
 pub struct List<T> {
     len: usize,
@@ -21,13 +35,35 @@ pub struct List<T> {
 
 // private methods
 impl<T> List<T> {
+    /// # 새 노드를 힙에 할당합니다.
+    ///
+    /// 이 함수는 `data`를 포함하는 새로운 `Node`를 힙에 할당하고,
+    /// 그 노드를 가리키는 `NonNull` 포인터를 반환합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `data`: 노드에 저장될 데이터입니다.
+    ///
+    /// # 반환값
+    ///
+    /// 새로 할당된 노드를 가리키는 `NonNull` 포인터입니다.
     fn alloc_node(data: T) -> NonNull<Node<T>> {
         let boxed_new_node = Box::new(Node::<T>::new(data));
-        NonNull::new(Box::into_raw(boxed_new_node)).unwrap() // fuck
+        NonNull::new(Box::into_raw(boxed_new_node)).unwrap()
     }
-    // fn free_node(node: NonNull<Node<T>>) {
-    //     unsafe { drop(Box::from_raw(node.as_ptr())) }
-    // }
+
+    /// # 지정된 위치의 노드에 대한 포인터를 반환합니다.
+    ///
+    /// 이 함수는 리스트의 `pos` 위치에 있는 노드를 가리키는 `NonNull` 포인터를 반환합니다.
+    /// `pos`가 범위를 벗어나면 `None`을 반환합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `pos`: 찾고자 하는 노드의 위치입니다.
+    ///
+    /// # 반환값
+    ///
+    /// `pos` 위치의 노드를 가리키는 `Option<NonNull<Node<T>>>`입니다.
     fn at(&self, pos: usize) -> Option<NonNull<Node<T>>> {
         if pos >= self.len() {
             return None;
@@ -39,11 +75,28 @@ impl<T> List<T> {
         }
         Some(target_node)
     }
+
+    /// # 리스트가 비어 있을 때 노드를 삽입합니다.
+    ///
+    /// 이 함수는 리스트가 비어 있을 때 `node`를 첫 번째이자 마지막 노드로 설정합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `node`: 삽입할 노드입니다.
     fn insert_when_empty(&mut self, node: NonNull<Node<T>>) {
         self.head = Some(node);
         self.tail = Some(node);
         self.len = 1;
     }
+
+    /// # 리스트의 마지막 요소를 제거하고 반환합니다.
+    ///
+    /// 이 함수는 리스트에 요소가 하나만 있을 때 그 요소를 제거하고 데이터를 반환합니다.
+    /// 리스트가 비어 있으면 에러를 반환합니다.
+    ///
+    /// # 반환값
+    ///
+    /// 제거된 요소의 데이터를 담은 `Result<T, &str>`입니다.
     fn pop_last(&mut self) -> Result<T, &str> {
         let result = if let Some(node) = self.head {
             unsafe { Ok((*Box::from_raw(node.as_ptr())).get_data()) }
@@ -59,6 +112,16 @@ impl<T> List<T> {
 
 // public methods
 impl<T> List<T> {
+    /// # 비어 있는 `List`를 생성합니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let list = List::<i32>::new();
+    /// assert!(list.is_empty());
+    /// ```
     pub fn new() -> Self {
         Self {
             len: 0usize,
@@ -66,6 +129,25 @@ impl<T> List<T> {
             tail: None,
         }
     }
+
+    /// # 슬라이스에서 `List`를 생성합니다.
+    ///
+    /// # 제네릭
+    ///
+    /// * `T`: `Clone` 트레이트를 구현해야 합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `slice`: `List`를 생성하는 데 사용될 슬라이스입니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let list = List::from_slice(&[1, 2, 3]);
+    /// assert_eq!(list.len(), 3);
+    /// ```
     pub fn from_slice(slice: &[T]) -> Self
     where
         T: Clone,
@@ -76,14 +158,51 @@ impl<T> List<T> {
         }
         list
     }
+
+    /// # 리스트의 요소 수를 반환합니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let mut list = List::new();
+    /// list.push_back(1);
+    /// assert_eq!(list.len(), 1);
+    /// ```
     pub fn len(&self) -> usize {
         self.len
     }
+
+    /// # 리스트가 비어 있는지 확인합니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let list = List::<i32>::new();
+    /// assert!(list.is_empty());
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.len == 0usize
     }
 
-    // 삽입
+    /// # 리스트의 맨 앞에 요소를 추가합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `data`: 추가할 요소입니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let mut list = List::new();
+    /// list.push_front(1);
+    /// assert_eq!(list.len(), 1);
+    /// ```
     pub fn push_front(&mut self, data: T) {
         let new_node = List::alloc_node(data);
         if self.is_empty() {
@@ -94,6 +213,22 @@ impl<T> List<T> {
             self.len += 1;
         }
     }
+
+    /// # 리스트의 맨 뒤에 요소를 추가합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `data`: 추가할 요소입니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let mut list = List::new();
+    /// list.push_back(1);
+    /// assert_eq!(list.len(), 1);
+    /// ```
     pub fn push_back(&mut self, data: T) {
         let new_node = List::alloc_node(data);
         if self.is_empty() {
@@ -104,6 +239,27 @@ impl<T> List<T> {
             self.len += 1;
         }
     }
+
+    /// # 지정된 위치에 요소를 삽입합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `data`: 삽입할 요소입니다.
+    /// * `pos`: 요소를 삽입할 위치입니다.
+    ///
+    /// # 반환값
+    ///
+    /// 삽입에 성공하면 `Ok(())`를, `pos`가 범위를 벗어나면 `Err`를 반환합니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let mut list = List::from_slice(&[1, 3]);
+    /// list.insert_at(2, 1).unwrap();
+    /// assert_eq!(list.len(), 3);
+    /// ```
     pub fn insert_at(&mut self, data: T, pos: usize) -> Result<(), &str> {
         // push back
         match pos {
@@ -128,6 +284,24 @@ impl<T> List<T> {
         }
     }
 
+    /// # 리스트의 첫 번째 요소를 제거하고 반환합니다.
+    ///
+    /// 리스트가 비어 있으면 `Err`를 반환합니다.
+    ///
+    /// # 반환값
+    ///
+    /// 제거된 요소의 데이터를 담은 `Result<T, &str>`입니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let mut list = List::from_slice(&[1, 2]);
+    /// assert_eq!(list.pop_front(), Ok(1));
+    /// assert_eq!(list.pop_front(), Ok(2));
+    /// assert!(list.pop_front().is_err());
+    /// ```
     pub fn pop_front(&mut self) -> Result<T, &str> {
         if self.len == 0 {
             Err("Error : out of range.")
@@ -141,6 +315,25 @@ impl<T> List<T> {
             result
         }
     }
+
+    /// # 리스트의 마지막 요소를 제거하고 반환합니다.
+    ///
+    /// 리스트가 비어 있으면 `Err`를 반환합니다.
+    ///
+    /// # 반환값
+    ///
+    /// 제거된 요소의 데이터를 담은 `Result<T, &str>`입니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let mut list = List::from_slice(&[1, 2]);
+    /// assert_eq!(list.pop_back(), Ok(2));
+    /// assert_eq!(list.pop_back(), Ok(1));
+    /// assert!(list.pop_back().is_err());
+    /// ```
     pub fn pop_back(&mut self) -> Result<T, &str> {
         if self.len == 0 {
             Err("Error : out of range.")
@@ -155,6 +348,27 @@ impl<T> List<T> {
         }
     }
 
+    /// # 지정된 위치의 요소를 제거하고 반환합니다.
+    ///
+    /// `pos`가 범위를 벗어나면 `Err`를 반환합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `pos`: 제거할 요소의 위치입니다.
+    ///
+    /// # 반환값
+    ///
+    /// 제거된 요소의 데이터를 담은 `Result<T, &str>`입니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let mut list = List::from_slice(&[1, 2, 3]);
+    /// assert_eq!(list.get(1), Ok(2));
+    /// assert_eq!(list.len(), 2);
+    /// ```
     pub fn get(&mut self, pos: usize) -> Result<T, &str> {
         if pos == 0 {
             return self.pop_front();
@@ -169,6 +383,27 @@ impl<T> List<T> {
             Err("Error : pos out of range.")
         }
     }
+
+    /// # 지정된 위치의 요소에 대한 참조를 반환합니다.
+    ///
+    /// `pos`가 범위를 벗어나면 `Err`를 반환합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `pos`: 참조할 요소의 위치입니다.
+    ///
+    /// # 반환값
+    ///
+    /// 요소에 대한 참조를 담은 `Result<&T, &str>`입니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let list = List::from_slice(&[1, 2, 3]);
+    /// assert_eq!(list.get_ref(1), Ok(&2));
+    /// ```
     pub fn get_ref(&self, pos: usize) -> Result<&T, &str> {
         if let Some(node) = self.at(pos) {
             unsafe { Ok(node.as_ref().get_data_ref()) }
@@ -176,6 +411,30 @@ impl<T> List<T> {
             Err("Error : pos out of range.")
         }
     }
+
+    /// # 지정된 위치의 요소에 대한 가변 참조를 반환합니다.
+    ///
+    /// `pos`가 범위를 벗어나면 `Err`를 반환합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `pos`: 참조할 요소의 위치입니다.
+    ///
+    /// # 반환값
+    ///
+    /// 요소에 대한 가변 참조를 담은 `Result<&mut T, &str>`입니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let mut list = List::from_slice(&[1, 2, 3]);
+    /// if let Ok(val) = list.get_mut_ref(1) {
+    ///     *val = 42;
+    /// }
+    /// assert_eq!(list.get_ref(1), Ok(&42));
+    /// ```
     pub fn get_mut_ref(&mut self, pos: usize) -> Result<&mut T, &str> {
         if let Some(mut node) = self.at(pos) {
             unsafe { Ok(node.as_mut().get_data_mut_ref()) }
@@ -183,6 +442,26 @@ impl<T> List<T> {
             Err("Error : pos out of range.")
         }
     }
+
+    /// # 지정된 위치의 요소를 제거합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `pos`: 제거할 요소의 위치입니다.
+    ///
+    /// # 반환값
+    ///
+    /// 제거에 성공하면 `Ok(())`를, `pos`가 범위를 벗어나면 `Err`를 반환합니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let mut list = List::from_slice(&[1, 2, 3]);
+    /// list.erase_at(1).unwrap();
+    /// assert_eq!(list.len(), 2);
+    /// ```
     pub fn erase_at(&mut self, pos: usize) -> Result<(), &str> {
         let result = self.get(pos);
         if result.is_ok() {
@@ -191,22 +470,55 @@ impl<T> List<T> {
             Err(result.err().unwrap())
         }
     }
+
+    /// # 리스트의 모든 요소를 제거합니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let mut list = List::from_slice(&[1, 2, 3]);
+    /// list.clear();
+    /// assert!(list.is_empty());
+    /// ```
     pub fn clear(&mut self) {
         // consume all node
         while self.pop_back().is_ok() {
             // do nothing
         }
     }
-
-    // into_iter()
-    // from_iter()
 }
 
 impl<'a, T> List<T> {
+    /// # 리스트에 대한 반복자를 반환합니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let list = List::from_slice(&[1, 2, 3]);
+    /// let mut iter = list.iter();
+    /// assert_eq!(iter.next(), Some(&1));
+    /// ```
     pub fn iter(&'a self) -> Iter<'a, T> {
         Iter::new(self)
     }
 
+    /// # 리스트에 대한 가변 반복자를 반환합니다.
+    ///
+    /// # 예제
+    ///
+    /// ```
+    /// use list::List;
+    ///
+    /// let mut list = List::from_slice(&[1, 2, 3]);
+    /// for val in list.iter_mut() {
+    ///     *val *= 2;
+    /// }
+    /// assert_eq!(list.get_ref(0), Ok(&2));
+    /// ```
     pub fn iter_mut(&'a mut self) -> IterMut<'a, T> {
         IterMut::new(self)
     }

--- a/collections/list/src/lib.rs
+++ b/collections/list/src/lib.rs
@@ -280,6 +280,16 @@ impl<T> std::iter::IntoIterator for List<T> {
     }
 }
 
+impl<T> std::iter::FromIterator<T> for List<T> {
+    fn from_iter<Itr: IntoIterator<Item = T>>(iter: Itr) -> Self {
+        let mut l = List::<T>::new();
+        for data in iter {
+            l.push_back(data);
+        }
+        l
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -475,5 +485,10 @@ mod tests {
             assert_eq!(val, i);
             val += 2;
         }
+    }
+    #[test]
+    fn test_from_iter() {
+        let l: List<i32> = [1, 2, 3, 4, 5, 6, 7].into_iter().collect();
+		assert_eq!(l, List::<i32>::from_slice(&[1, 2, 3, 4, 5, 6, 7]));
     }
 }

--- a/collections/list/src/node.rs
+++ b/collections/list/src/node.rs
@@ -1,13 +1,39 @@
+//! # 연결 리스트의 노드
+//!
+//! 이 모듈은 `List`에서 사용되는 `Node` 구조체와 관련 함수들을 포함합니다.
+
 use std::ptr::NonNull;
 
+/// # 연결 리스트의 노드
+///
+/// `Node`는 이중 연결 리스트의 개별 요소를 나타냅니다.
+///
+/// # 제네릭
+///
+/// * `T`: 노드에 저장될 데이터의 타입입니다.
+///
+/// # 필드
+///
+/// * `data`: 노드에 저장되는 데이터입니다.
+/// * `next_node`: 다음 노드를 가리키는 포인터입니다.
+/// * `prev_node`: 이전 노드를 가리키는 포인터입니다.
 pub struct Node<T> {
-    data: T, // maybe uninit
+    data: T,
     next_node: Option<NonNull<Node<T>>>,
     prev_node: Option<NonNull<Node<T>>>,
 }
 
 // public
 impl<T> Node<T> {
+    /// # 새 노드를 생성합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `data`: 노드에 저장될 데이터입니다.
+    ///
+    /// # 반환값
+    ///
+    /// `data`를 포함하는 새로운 `Node`입니다.
     pub fn new(data: T) -> Self {
         Node {
             data,
@@ -15,24 +41,70 @@ impl<T> Node<T> {
             prev_node: None,
         }
     }
+
+    /// # 노드를 소비하고 데이터를 반환합니다.
+    ///
+    /// 이 함수는 노드의 연결을 끊고, 노드가 소유한 데이터를 반환합니다.
+    ///
+    /// # 반환값
+    ///
+    /// 노드가 가지고 있던 데이터입니다.
     pub fn get_data(self) -> T {
         let mut temp = self;
         Node::splice_left_right(&mut temp);
         temp.data
     }
+
+    /// # 노드의 데이터에 대한 참조를 반환합니다.
+    ///
+    /// # 반환값
+    ///
+    /// 노드의 데이터에 대한 참조입니다.
     pub fn get_data_ref(&self) -> &T {
         &self.data
     }
+
+    /// # 노드의 데이터에 대한 가변 참조를 반환합니다.
+    ///
+    /// # 반환값
+    ///
+    /// 노드의 데이터에 대한 가변 참조입니다.
     pub fn get_data_mut_ref(&mut self) -> &mut T {
         &mut self.data
     }
 
+    /// # 두 노드를 연결합니다.
+    ///
+    /// `left_node`의 `next_node`를 `right_node`로 설정하고,
+    /// `right_node`의 `prev_node`를 `left_node`로 설정합니다.
+    ///
+    /// # 안전하지 않은 코드
+    ///
+    /// 이 함수는 `NonNull` 포인터를 역참조하므로 `unsafe` 블록이 필요합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `left_node`: 연결할 왼쪽 노드입니다.
+    /// * `right_node`: 연결할 오른쪽 노드입니다.
     pub fn link_nodes(mut left_node: NonNull<Node<T>>, mut right_node: NonNull<Node<T>>) {
         unsafe {
             left_node.as_mut().next_node = Some(right_node);
             right_node.as_mut().prev_node = Some(left_node);
         }
     }
+
+    /// # 연결된 노드 앞에 단일 노드를 삽입합니다.
+    ///
+    /// `single_node`를 `chained_node` 앞에 삽입합니다.
+    ///
+    /// # 안전하지 않은 코드
+    ///
+    /// 이 함수는 `NonNull` 포인터를 역참조하므로 `unsafe` 블록이 필요합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `single_node`: 삽입할 단일 노드입니다.
+    /// * `chained_node`: `single_node`가 삽입될 위치의 노드입니다.
     pub fn insert_before(single_node: NonNull<Node<T>>, mut chained_node: NonNull<Node<T>>) {
         // link prev of chain
         unsafe {
@@ -42,22 +114,74 @@ impl<T> Node<T> {
         }
         Node::link_nodes(single_node, chained_node);
     }
+
+    /// # 다음 노드를 반환합니다.
+    ///
+    /// # 안전하지 않은 코드
+    ///
+    /// 이 함수는 `NonNull` 포인터를 역참조하므로 `unsafe` 블록이 필요합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `cur_node`: 현재 노드입니다.
+    ///
+    /// # 반환값
+    ///
+    /// 다음 노드를 가리키는 `Option<NonNull<Node<T>>>`입니다.
     pub fn get_next_node(cur_node: NonNull<Node<T>>) -> Option<NonNull<Node<T>>> {
         unsafe { cur_node.as_ref().next_node }
     }
+
+    /// # 이전 노드를 반환합니다.
+    ///
+    /// # 안전하지 않은 코드
+    ///
+    /// 이 함수는 `NonNull` 포인터를 역참조하므로 `unsafe` 블록이 필요합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `cur_node`: 현재 노드입니다.
+    ///
+    /// # 반환값
+    ///
+    /// 이전 노드를 가리키는 `Option<NonNull<Node<T>>>`입니다.
     pub fn get_prev_node(cur_node: NonNull<Node<T>>) -> Option<NonNull<Node<T>>> {
         unsafe { cur_node.as_ref().prev_node }
     }
+
+    /// # 다음 노드와의 연결을 끊습니다.
+    ///
+    /// # 안전하지 않은 코드
+    ///
+    /// 이 함수는 `NonNull` 포인터를 역참조하므로 `unsafe` 블록이 필요합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `node`: 연결을 끊을 노드입니다.
     pub fn unlink_next(mut node: NonNull<Node<T>>) {
         unsafe {
             node.as_mut().next_node = None;
         }
     }
+
+    /// # 이전 노드와의 연결을 끊습니다.
+    ///
+    /// # 안전하지 않은 코드
+    ///
+    /// 이 함수는 `NonNull` 포인터를 역참조하므로 `unsafe` 블록이 필요합니다.
+    ///
+    /// # 인수
+    ///
+    /// * `node`: 연결을 끊을 노드입니다.
     pub fn unlink_prev(mut node: NonNull<Node<T>>) {
         unsafe {
             node.as_mut().prev_node = None;
         }
     }
+
+    /// # 리스트에서 노드를 잘라냅니다.
+    ///
+    /// 이 노드의 이전 노드와 다음 노드를 직접 연결하여, 이 노드를 리스트에서 제거합니다.
     fn splice_left_right(&mut self) {
         // link prev and next of self
         if self.next_node.is_some() && self.prev_node.is_some() {

--- a/collections/list/src/node.rs
+++ b/collections/list/src/node.rs
@@ -1,0 +1,115 @@
+use std::ptr::NonNull;
+
+pub struct Node<T> {
+    data: T, // maybe uninit
+    next_node: Option<NonNull<Node<T>>>,
+    prev_node: Option<NonNull<Node<T>>>,
+}
+
+// public
+impl<T> Node<T> {
+    pub fn new(data: T) -> Self {
+        Node {
+            data,
+            next_node: None,
+            prev_node: None,
+        }
+    }
+    pub fn get_data(self) -> T {
+        let mut temp = self;
+        Node::splice_left_right(&mut temp);
+        temp.data
+    }
+    pub fn get_data_ref(&self) -> &T {
+        &self.data
+    }
+    pub fn get_data_mut_ref(&mut self) -> &mut T {
+        &mut self.data
+    }
+
+    pub fn link_nodes(mut left_node: NonNull<Node<T>>, mut right_node: NonNull<Node<T>>) {
+        unsafe {
+            left_node.as_mut().next_node = Some(right_node);
+            right_node.as_mut().prev_node = Some(left_node);
+        }
+    }
+    pub fn insert_before(single_node: NonNull<Node<T>>, mut chained_node: NonNull<Node<T>>) {
+        // link prev of chain
+        unsafe {
+            if chained_node.as_mut().prev_node.is_some() {
+                Node::link_nodes(chained_node.as_mut().prev_node.unwrap(), single_node);
+            }
+        }
+        Node::link_nodes(single_node, chained_node);
+    }
+    pub fn get_next_node(cur_node: NonNull<Node<T>>) -> Option<NonNull<Node<T>>> {
+        unsafe { cur_node.as_ref().next_node }
+    }
+    pub fn get_prev_node(cur_node: NonNull<Node<T>>) -> Option<NonNull<Node<T>>> {
+        unsafe { cur_node.as_ref().prev_node }
+    }
+    pub fn unlink_next(mut node: NonNull<Node<T>>) {
+        unsafe {
+            node.as_mut().next_node = None;
+        }
+    }
+    pub fn unlink_prev(mut node: NonNull<Node<T>>) {
+        unsafe {
+            node.as_mut().prev_node = None;
+        }
+    }
+    fn splice_left_right(&mut self) {
+        // link prev and next of self
+        if self.next_node.is_some() && self.prev_node.is_some() {
+            Node::link_nodes(self.prev_node.unwrap(), self.next_node.unwrap());
+        } else if self.next_node.is_some() {
+            Node::unlink_prev(self.next_node.unwrap());
+        } else if self.prev_node.is_some() {
+            Node::unlink_next(self.prev_node.unwrap());
+        }
+    }
+}
+
+// partial eq
+impl<T> PartialEq for Node<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+// eq
+impl<T> Eq for Node<T>
+where
+    Node<T>: PartialEq,
+    T: Eq,
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_node_construct() {
+        let node = Node::<i32>::new(44);
+        assert_eq!(44, node.data);
+    }
+    #[test]
+    fn test_node_link() {
+        let node1 = Box::new(Node::<i32>::new(42));
+        let node2 = Box::new(Node::<i32>::new(43));
+
+        Node::link_nodes(
+            NonNull::new(Box::leak(node1) as *mut Node<i32>).unwrap(),
+            NonNull::new(Box::leak(node2) as *mut Node<i32>).unwrap(),
+        );
+    }
+    #[test]
+    fn test_node_get() {
+        let node = Node::new(44);
+        assert_eq!(44, Node::get_data(node));
+    }
+}


### PR DESCRIPTION
# list 구현
## Overview
double linked list 구현. rust에서 널리 사용되는 iterator 트레잇을 구현해 보았습니다.
- NonNull 포인터로 구현한 노드
- 3종의 이터레이터(참조, 가변 참조, 소유) 구현

## PR Type
어떤 변경 사항이 있나요?

- [x] feat

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
